### PR TITLE
Ajout du service de mailing Resend

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -36,3 +36,6 @@ DATABASE_URL="postgres://business_user:business_password@localhost:5432/business
 
 ## 64 hex characters
 ENCRYPTION_KEY="0465123874555555046512387455555504651238745555550465123874555555$"
+
+RESEND_API_KEY=pk_live_xxx
+RESEND_FROM="OpenSource Together <noreply@opensourcetogether.dev>"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -52,6 +52,7 @@
     "class-validator": "^0.14.1",
     "octokit": "^5.0.3",
     "reflect-metadata": "^0.2.2",
+    "resend": "^4.6.0",
     "rxjs": "^7.8.1",
     "supertokens-nestjs": "^0.0.2",
     "supertokens-node": "^22.0.1",

--- a/apps/server/pnpm-lock.yaml
+++ b/apps/server/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+      resend:
+        specifier: ^4.6.0
+        version: 4.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -1485,11 +1488,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
+  '@react-email/render@1.1.2':
+    resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
   '@sentry-internal/node-cpu-profiler@2.2.0':
     resolution: {integrity: sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ==}
@@ -2419,6 +2432,19 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dotenv-expand@12.0.1:
     resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
     engines: {node: '>=12'}
@@ -2465,6 +2491,10 @@ packages:
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2640,6 +2670,9 @@ packages:
 
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2882,6 +2915,13 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -3239,6 +3279,9 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -3559,6 +3602,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3589,6 +3635,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   peek-readable@5.4.2:
     resolution: {integrity: sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==}
@@ -3738,8 +3787,20 @@ packages:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
+  react-dom@19.1.0:
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+    peerDependencies:
+      react: ^19.1.0
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
+
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+    engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -3773,6 +3834,10 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resend@4.6.0:
+    resolution: {integrity: sha512-D5T2I82FvEUYFlrHzaDvVtr5ADHdhuoLaXgLFGABKyNtQgPWIuz0Vp2L2Evx779qjK37aF4kcw1yXJDHhA2JnQ==}
+    engines: {node: '>=18'}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -3832,6 +3897,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
@@ -3846,6 +3914,9 @@ packages:
   seek-bzip@2.0.0:
     resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
     hasBin: true
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
@@ -5891,9 +5962,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@react-email/render@1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.5.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-promise-suspense: 0.3.4
+
   '@scarf/scarf@1.4.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   '@sentry-internal/node-cpu-profiler@2.2.0':
     dependencies:
@@ -6960,6 +7044,24 @@ snapshots:
 
   diff@4.0.2: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dotenv-expand@12.0.1:
     dependencies:
       dotenv: 16.4.7
@@ -6998,6 +7100,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  entities@4.5.0: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -7239,6 +7343,8 @@ snapshots:
       tmp: 0.0.33
 
   fast-content-type-parse@3.0.0: {}
+
+  fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -7500,6 +7606,21 @@ snapshots:
       function-bind: 1.1.2
 
   html-escaper@2.0.2: {}
+
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-cache-semantics@4.1.1: {}
 
@@ -8039,6 +8160,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  leac@0.6.0: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -8314,6 +8437,11 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -8332,6 +8460,8 @@ snapshots:
   path-to-regexp@8.2.0: {}
 
   path-type@4.0.0: {}
+
+  peberminta@0.9.0: {}
 
   peek-readable@5.4.2: {}
 
@@ -8452,7 +8582,18 @@ snapshots:
       iconv-lite: 0.6.3
       unpipe: 1.0.0
 
+  react-dom@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+
   react-is@18.3.1: {}
+
+  react-promise-suspense@0.3.4:
+    dependencies:
+      fast-deep-equal: 2.0.1
+
+  react@19.1.0: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -8489,6 +8630,13 @@ snapshots:
       - supports-color
 
   requires-port@1.0.0: {}
+
+  resend@4.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@react-email/render': 1.1.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   resolve-alpn@1.2.1: {}
 
@@ -8547,6 +8695,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.26.0: {}
+
   schema-utils@3.3.0:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -8565,6 +8715,10 @@ snapshots:
   seek-bzip@2.0.0:
     dependencies:
       commander: 6.2.1
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   semver-regex@4.0.5: {}
 

--- a/apps/server/src/contexts/contexts.module.ts
+++ b/apps/server/src/contexts/contexts.module.ts
@@ -6,6 +6,7 @@ import { TechStackInfrastructure } from './techstack/infrastructure/techstack.in
 import { ProjectRoleInfrastructure } from './project-role/infrastructure/project-role.infrastructure';
 import { GithubInfrastructure } from './github/infrastructure/github.infrastructure';
 import { CategoryInfrastructure } from './category/infrastructure/category.infrastructure';
+import { MailingModule } from '@/mailing/infrastructure/mailing.infrastructure';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { CategoryInfrastructure } from './category/infrastructure/category.infra
     TechStackInfrastructure,
     GithubInfrastructure,
     CategoryInfrastructure,
+    MailingModule,
   ],
   exports: [
     UserInfrastructure,

--- a/apps/server/src/mailing/README.md
+++ b/apps/server/src/mailing/README.md
@@ -1,0 +1,95 @@
+# 📧 Service de Mailing
+
+Service transversal pour l'envoi d'e-mails transactionnels via **Resend**.
+
+## 🚀 Utilisation rapide
+
+### 1. Injection du service
+
+```typescript
+import { Inject } from '@nestjs/common';
+import {
+  MAILING_SERVICE_PORT,
+  MailingServicePort,
+} from '@/mailing/ports/mailing.service.port';
+
+@Injectable()
+export class WelcomeUserCommandHandler {
+  constructor(
+    @Inject(MAILING_SERVICE_PORT)
+    private readonly mailingService: MailingServicePort,
+  ) {}
+
+  async execute(command: WelcomeUserCommand): Promise<Result<void, string>> {
+    const result = await this.mailingService.sendEmail({
+      to: command.userEmail,
+      subject: 'Bienvenue sur OpenSource Together ! 🎉',
+      html: `<h1>Salut ${command.username} !</h1><p>Ravi de t'accueillir...</p>`,
+      text: `Salut ${command.username} ! Ravi de t'accueillir...`,
+    });
+
+    if (!result.success) {
+      return Result.fail('WELCOME_EMAIL_FAILED');
+    }
+
+    return Result.ok(undefined);
+  }
+}
+```
+
+### 2. Interface du service
+
+```typescript
+interface SendEmailPayload {
+  to: string; // destinataire
+  subject: string; // objet du mail
+  html: string; // contenu HTML
+  text?: string; // version texte (optionnel)
+  from?: string; // expéditeur (défaut: RESEND_FROM)
+}
+
+// Retourne toujours un Result<void, string>
+await mailingService.sendEmail(payload);
+```
+
+## ⚙️ Configuration
+
+Ajouter dans `.env` :
+
+```env
+RESEND_API_KEY=re_xxxxxxxxx
+RESEND_FROM="OpenSource Together <noreply@opensourcetogether.dev>"
+```
+
+> **Note** : Le module est `@Global()`, aucun import supplémentaire requis.
+
+## 📮 Cas d'usage principaux
+
+| Événement               | Déclencheur                   | Template suggéré                       |
+| ----------------------- | ----------------------------- | -------------------------------------- |
+| **Bienvenue**           | Inscription utilisateur       | Présentation plateforme + premiers pas |
+| **Invitation projet**   | Propriétaire invite un membre | Détails projet + lien d'acceptation    |
+| **Reset password**      | Demande de réinitialisation   | Lien sécurisé + expiration             |
+| **Candidature reçue**   | Soumission candidature        | Confirmation + prochaines étapes       |
+| **Candidature envoyée** | Réponse du propriétaire       | Acceptation/refus + feedback           |
+
+## 🔧 Bonnes pratiques
+
+- ✅ **Toujours fournir `text`** en plus de `html` (accessibilité)
+- ✅ **Gérer les échecs** : le service retourne `Result.fail('MAIL_SEND_FAILED')`
+- ✅ **Contenu statique** : le service ne gère pas les templates (déléguer à l'appelant)
+- ⚠️ **Pas de retry automatique** : implémenter côté use-case si nécessaire
+
+## 🔄 Gestion d'erreurs
+
+```typescript
+const result = await mailingService.sendEmail(payload);
+
+if (!result.success) {
+  this.logger.error(`Failed to send email: ${result.error}`);
+  // Stratégie de fallback ou notification admin
+  return Result.fail('EMAIL_DELIVERY_FAILED');
+}
+```
+
+---

--- a/apps/server/src/mailing/infrastructure/mailing.infrastructure.ts
+++ b/apps/server/src/mailing/infrastructure/mailing.infrastructure.ts
@@ -1,0 +1,15 @@
+import { Global, Module } from '@nestjs/common';
+import { ResendMailingService } from './resend.mailing.service';
+import { MAILING_SERVICE_PORT } from '../ports/mailing.service.port';
+
+@Global() // module global pour injection partout
+@Module({
+  providers: [
+    {
+      provide: MAILING_SERVICE_PORT,
+      useClass: ResendMailingService,
+    },
+  ],
+  exports: [MAILING_SERVICE_PORT],
+})
+export class MailingModule {}

--- a/apps/server/src/mailing/infrastructure/resend.mailing.service.ts
+++ b/apps/server/src/mailing/infrastructure/resend.mailing.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Result } from '@/libs/result';
+import {
+  MailingServicePort,
+  SendEmailPayload,
+} from '../ports/mailing.service.port';
+import { Resend } from 'resend';
+
+@Injectable()
+export class ResendMailingService implements MailingServicePort {
+  private readonly resend = new Resend(process.env.RESEND_API_KEY!);
+  private readonly logger = new Logger(ResendMailingService.name);
+
+  async sendEmail(payload: SendEmailPayload): Promise<Result<void, string>> {
+    try {
+      await this.resend.emails.send({
+        from: payload.from ?? process.env.RESEND_FROM!, // ex: "noreply@opensourcetogether.dev"
+        to: payload.to,
+        subject: payload.subject,
+        html: payload.html,
+        text: payload.text,
+      });
+      return Result.ok(undefined);
+    } catch (err: any) {
+      this.logger.error('Failed to send email', err);
+      return Result.fail('MAIL_SEND_FAILED');
+    }
+  }
+}

--- a/apps/server/src/mailing/ports/mailing.service.port.ts
+++ b/apps/server/src/mailing/ports/mailing.service.port.ts
@@ -1,0 +1,15 @@
+import { Result } from '@/libs/result';
+
+export const MAILING_SERVICE_PORT = Symbol('MailingService');
+
+export interface SendEmailPayload {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string; // défaut défini dans .env
+}
+
+export interface MailingServicePort {
+  sendEmail(payload: SendEmailPayload): Promise<Result<void, string>>;
+}


### PR DESCRIPTION
## 🚀 Objectif
Intégrer un **service de mailing transactionnel** basé sur l’API **Resend** afin de couvrir les besoins suivants :
- invitation de membres à un projet,
- réinitialisation de mot de passe,
- e-mail de bienvenue,
- notifications de candidature (envoyée / reçue).

Le service est déclaré comme **module global** (`@Global()`), donc injectable partout via son _port_ (`MAILING_SERVICE_PORT`).

---

## ✨ Principaux apports
| Fichier | Rôle |
|---------|------|
| `src/mailing/ports/mailing.service.port.ts` | Définition du port + `SendEmailPayload` |
| `src/mailing/infrastructure/resend.mailing.service.ts` | Implémentation concrète via SDK Resend |
| `src/mailing/infrastructure/mailing.infrastructure.ts` | Module NestJS (`@Global()`) |
| `src/mailing/README.md` | Guide d’usage et bonnes pratiques |

---

## ⚙️ Variables d’environnement
Ajouter dans **.env** :

```env
# Clé API Resend
RESEND_API_KEY=re_xxxxxxxxxxxxxx         

# Expéditeur par défaut
RESEND_FROM="OpenSource Together <noreply@opensourcetogether.dev>"
```

> Sans ces variables, le service lèvera une erreur de type `MAIL_SEND_FAILED`.

---

## 🛠️ API du service : `sendEmail(payload)`
```ts
interface SendEmailPayload {
  to: string;           // Destinataire (obligatoire)
  subject: string;      // Objet du mail   (obligatoire)
  html: string;         // Contenu HTML    (obligatoire)
  text?: string;        // Contenu texte   (recommandé 💚)
  from?: string;        // Expéditeur ; fallback = RESEND_FROM
}
```
- `from` : permet de surcharger l’expéditeur par défaut (utile pour différencier les canaux d’e-mail).  
- `to` : adresse du/​des destinataires (chaîne ou tableau géré par Resend).  
- `subject` : objet visible dans la boîte de réception ; **éviter les emoji seuls** qui déclenchent certains filtres spam.  
- `html` : version HTML principale ; **obligatoire** car Resend refuse les messages vides.  
- `text` : version _plain-text_ ; améliore l’accessibilité + délivrabilité. Si non fournie, certains filtres antispam pénalisent le message.

La méthode renvoie toujours un `Result<void, string>` :
- **`Result.ok()`** → envoi accepté par Resend.  
- **`Result.fail('MAIL_SEND_FAILED')`** → erreur réseau / clé API incorrecte / payload invalide.

---

## 🔍 Exemple rapide d’injection
```ts
@Injectable()
export class ResetPasswordCommandHandler {
  constructor(
    @Inject(MAILING_SERVICE_PORT)
    private readonly mailing: MailingServicePort,
  ) {}

  async execute(cmd: ResetPasswordCommand) {
    const { userEmail, token } = cmd;

    return this.mailing.sendEmail({
      to: userEmail,
      subject: 'Réinitialisation de votre mot de passe',
      html: `<p>Voici votre lien : <a href="${token}">Reset</a></p>`,
      text: `Lien de réinitialisation : ${token}`,
    });
  }
}
```