### PR TITLE
fix: add missing projectGoals field to project transformation and val…

### DIFF
--- a/apps/web/src/features/projects/services/project-transform.service.ts
+++ b/apps/web/src/features/projects/services/project-transform.service.ts
@@ -59,5 +59,6 @@ export const transformProjectForApiUpdate = (
     techStacks: formData.techStack || [],
     categories: formData.categories || [],
     keyFeatures: formData.keyFeatures?.map((feature) => feature.feature) || [],
+    projectGoals: formData.projectGoals?.map((goal) => goal.goal) || [],
   };
 };

--- a/apps/web/src/features/projects/validations/project.schema.ts
+++ b/apps/web/src/features/projects/validations/project.schema.ts
@@ -104,6 +104,7 @@ export const updateProjectApiSchema = z.object({
   keyFeatures: z
     .array(z.string())
     .min(1, "Au moins une fonctionnalité clé est requise"),
+  projectGoals: z.array(z.string()).min(1, "Au moins un objectif est requis"),
   externalLinks: z
     .array(
       z.object({


### PR DESCRIPTION
- Enhanced the project transformation service to include projectGoals from formData.
- Updated the validation schema to require at least one project goal during project updates.