### PR TITLE
Rendre l'endpoint profil public

### DIFF
--- a/apps/server/src/contexts/profile/infrastructure/controllers/profile.controller.ts
+++ b/apps/server/src/contexts/profile/infrastructure/controllers/profile.controller.ts
@@ -171,9 +171,9 @@ export class ProfileController {
     return GetProjectsByUserIdResponseDto.toResponse(result.value);
   }
 
+  @PublicAccess()
   @Get(':id')
   @ApiOperation({ summary: 'Récupérer un profil par son ID' })
-  @ApiCookieAuth('sAccessToken')
   @ApiParam({
     name: 'id',
     description: "ID de l'utilisateur dont on veut récupérer le profil",
@@ -209,14 +209,6 @@ export class ProfileController {
       message: 'Profile not found',
       error: 'Not Found',
       statusCode: 404,
-    },
-  })
-  @ApiResponse({
-    status: 401,
-    description: 'Non authentifié',
-    example: {
-      message: 'unauthorised',
-      statusCode: 401,
     },
   })
   async getProfileById(@Param('id') id: string): Promise<ProfileResponseDto> {


### PR DESCRIPTION
Make GET /v1/profile/{id} public to allow unauthenticated access to user profiles.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c59ab666-b2a7-456d-9dfe-9d1dd38eb599) · [Cursor](https://cursor.com/background-agent?bcId=bc-c59ab666-b2a7-456d-9dfe-9d1dd38eb599)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)