### PR TITLE
fix: validate user existence before updating GitHub credentials

### DIFF
--- a/apps/server/src/contexts/github/infrastructure/repositories/prisma.user-github-credentials.repository.ts
+++ b/apps/server/src/contexts/github/infrastructure/repositories/prisma.user-github-credentials.repository.ts
@@ -41,6 +41,16 @@ export class PrismaUserGitHubCredentialsRepository
     props: UserGitHubCredentialsData,
   ): Promise<Result<UserGitHubCredentialsData, string>> {
     try {
+      const userExists = await this.prisma.user.findUnique({
+        where: { id: props.userId },
+        select: { id: true },
+      });
+
+      if (!userExists) {
+        this.Logger.error(`User with id ${props.userId} not found`);
+        return Result.fail('User not found');
+      }
+
       const updatedCredentials = await this.prisma.userGitHubCredentials.upsert(
         {
           where: { userId: props.userId },


### PR DESCRIPTION
- Added a check to ensure the user exists in the database before attempting to update their GitHub credentials.
- Improved error logging to provide clearer feedback when a user is not found, enhancing the robustness of the credential management process.